### PR TITLE
feat(manage-merge-queue): add configurability to auto-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ Additionally, the following parameters can be used for additional control over t
  * You can also pass `login` and `slack_webhook_url` to notify the PR author when they are in the 1st position of the merge queue.
  * You can pass `auto_merge` as false to disable auto-merge for a PR when it is in the 1st position of the merge queue.
 
-
 ### [move-project-card](.github/workflows/move-project-card.yml)
 * Moves a GitHub Project card to a new column, using the `project_origin_column_name` and`project_destination_column_name` you provide.
 * In order to move a card from one place to another, it must already exist.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Additionally, the following parameters can be used for additional control over t
     * Adding the `JUMP THE QUEUE` label to a PR will make that PR first in the queue immediately.
     * When a PR is merged, it automatically updates the first-queued PR with the default branch.
  * You can also pass `login` and `slack_webhook_url` to notify the PR author when they are in the 1st position of the merge queue.
+ * You can pass `auto_merge` as false to disable auto-merge for a PR when it is in the 1st position of the merge queue.
+
 
 ### [move-project-card](.github/workflows/move-project-card.yml)
 * Moves a GitHub Project card to a new column, using the `project_origin_column_name` and`project_destination_column_name` you provide.

--- a/src/helpers/manage-merge-queue.ts
+++ b/src/helpers/manage-merge-queue.ts
@@ -86,14 +86,6 @@ export const removePrFromQueue = async (pullRequest: PullRequest) => {
 
 const addPrToQueue = async (pullRequest: PullRequest, queuePosition: number, auto_merge: boolean) => {
   if (auto_merge) {
-    await Promise.resolve(
-      octokit.issues.addLabels({
-        labels: [`${QUEUED_FOR_MERGE_PREFIX} #${queuePosition}`],
-        issue_number: context.issue.number,
-        ...context.repo
-      })
-    );
-  } else {
     await Promise.all([
       octokit.issues.addLabels({
         labels: [`${QUEUED_FOR_MERGE_PREFIX} #${queuePosition}`],
@@ -102,6 +94,14 @@ const addPrToQueue = async (pullRequest: PullRequest, queuePosition: number, aut
       }),
       enableAutoMerge(pullRequest.node_id)
     ]);
+  } else {
+    await Promise.resolve(
+      octokit.issues.addLabels({
+        labels: [`${QUEUED_FOR_MERGE_PREFIX} #${queuePosition}`],
+        issue_number: context.issue.number,
+        ...context.repo
+      })
+    );
   }
 };
 

--- a/test/helpers/manage-merge-queue.test.ts
+++ b/test/helpers/manage-merge-queue.test.ts
@@ -277,35 +277,6 @@ describe('manageMergeQueue', () => {
   });
 
   describe('slack reminder integration', () => {
-    const auto_merge = true;
-    const login = 'test';
-    const slack_webhook_url = 'https://hooks.slack.com/workflows/1234567890';
-
-    it('should not notify user if queue position greater than 2', async () => {
-      const queuedPrs = [
-        { labels: [{ name: READY_FOR_MERGE_PR_LABEL }] },
-        { labels: [{ name: READY_FOR_MERGE_PR_LABEL }] },
-        { labels: [{ name: READY_FOR_MERGE_PR_LABEL }] },
-        { labels: [{ name: READY_FOR_MERGE_PR_LABEL }] },
-        { labels: [{ name: READY_FOR_MERGE_PR_LABEL }] }
-      ];
-      (octokit.pulls.list as unknown as Mocktokit).mockImplementation(async ({ page }) => ({
-        data: page === 1 ? queuedPrs : []
-      }));
-      (octokit.pulls.get as unknown as Mocktokit).mockImplementation(async () => ({
-        data: {
-          merged: false,
-          head: { sha: 'sha' },
-          labels: [{ name: READY_FOR_MERGE_PR_LABEL }, { name: 'QUEUED FOR MERGE #5' }]
-        }
-      }));
-      await manageMergeQueue({ login, slack_webhook_url, auto_merge });
-
-      expect(octokitGraphql).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('slack reminder integration', () => {
     const login = 'test';
     const slack_webhook_url = 'https://hooks.slack.com/workflows/1234567890';
     const queuedPrs = [{ labels: [{ name: READY_FOR_MERGE_PR_LABEL }] }];


### PR DESCRIPTION
Adding the ability to have queue without auto-merge.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- 

### :link: Related Issues
- 
